### PR TITLE
Updated syntax in 'Deployed Site' photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An original npm install and npm intialize will need to be ran in the user's term
 
 ## 3. Preview
 
-  ![Travelers Landing](public\website.png)
+  ![Travelers Landing](public/website.png)
 
 
 ## 4. Deployed Site


### PR DESCRIPTION
Correcting a syntax error in the markdown code for the README that displays an image of the 'Deployed Site' that I missed during my review